### PR TITLE
Improve static password format validation

### DIFF
--- a/src/ui/staticpage.cpp
+++ b/src/ui/staticpage.cpp
@@ -76,8 +76,11 @@ StaticPage::StaticPage(QWidget *parent) :
     ui->quickResultsWidget->resizeColumnsToContents();
     ui->advResultsWidget->resizeColumnsToContents();
 
-    QRegExp rx("^[a-f0-9]{0,72}$");
-    ui->quickScanCodesTxt->setValidator(new QRegExpValidator(rx, this));
+    QRegExp rxScan("[A-Fa-f0-9]{,76}");
+    ui->quickScanCodesTxt->setValidator(new QRegExpValidator(rxScan, this));
+
+    QRegExp rxText("(\\\\[tn\\\\]|.){,38}");
+    ui->quickStaticTxt->setValidator(new QRegExpValidator(rxText, this));
 
     scanedit = NULL;
 }
@@ -357,6 +360,9 @@ void StaticPage::on_quickStaticTxt_textEdited(const QString &txt) {
 }
 
 void StaticPage::on_quickStaticTxt_returnPressed() {
+    if (!ui->quickInsertTabBtn->isEnabled())
+        return;
+
     QString text = ui->quickStaticTxt->text() + "\\n";
     ui->quickStaticTxt->setText(text);
     on_quickStaticTxt_textEdited(text);


### PR DESCRIPTION
- Don't reject upper-case scan codes
- Allow 76 characters in the scan code field (was limited to 72)
- Limit the static text field to 38 characters, taking escape sequences
into account
- Enforce the 38 characters limit when adding newlines with the Return key