### PR TITLE
fix(README): replacing 'libusb-devel' by 'libusb-compat-0.1-devel' for Fedora install command

### DIFF
--- a/README
+++ b/README
@@ -67,7 +67,7 @@ On Debian-based systems (Ubuntu, Linux Mint, etc.):
 
 On Fedora-based systems (RHEL, CentOS, Scientific Linux, etc.):
 -----------
-  $ sudo dnf install libusb-devel qt-devel ykpers-devel libyubikey-devel
+  $ sudo dnf install libusb-compat-0.1-devel qt-devel ykpers-devel libyubikey-devel
 -----------
 
 Command-line build


### PR DESCRIPTION
`libusb-devel`'s latest release is for Fedora 36